### PR TITLE
Add logging defaults

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+RELEASE_TYPE: major 
+
+Include Logback and akka-slf4j as dependencies.
+
+akka-slf4j is required to ensure akka logs use the sl4j adapter: https://doc.akka.io/docs/akka/current/logging.html
+
+Consumers will need to remove their own references to Logback and akka-slf4j.
+
+This change also includes some tests to check config is set correctly.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,19 +18,36 @@ object Dependencies {
   lazy val versions = new {
     val akka     = "2.6.4"
     val typesafe = "1.3.2"
+    val scalatest = "3.1.1"
+    val logback = "1.2.3"
   }
+
+  val logbackDependencies = Seq(
+    "ch.qos.logback" % "logback-classic" % versions.logback,
+    "ch.qos.logback" % "logback-core" % versions.logback,
+    "ch.qos.logback" % "logback-access" % versions.logback
+  )
 
   val akkaDependencies: Seq[ModuleID] = Seq(
     "com.typesafe.akka" %% "akka-actor" % versions.akka,
-    "com.typesafe.akka" %% "akka-stream" % versions.akka
+    "com.typesafe.akka" %% "akka-stream" % versions.akka,
+    // Force Akka to use SL4J logging adapter
+    // https://doc.akka.io/docs/akka/current/logging.html#slf4j
+    "com.typesafe.akka" %% "akka-slf4j" % versions.akka,
   )
 
   val typesafeDependencies: Seq[ModuleID] = Seq(
     "com.typesafe" % "config" % versions.typesafe
   )
 
+  val scalatestDependencies = Seq[ModuleID](
+    "org.scalatest" %% "scalatest" % versions.scalatest % "test"
+  )
+
   val libraryDependencies =
     akkaDependencies ++
+    logbackDependencies ++
     typesafeDependencies ++
+    scalatestDependencies ++
     WellcomeDependencies.fixturesLibrary
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}

--- a/src/main/scala/uk/ac/wellcome/typesafe/Runnable.scala
+++ b/src/main/scala/uk/ac/wellcome/typesafe/Runnable.scala
@@ -1,7 +1,9 @@
 package uk.ac.wellcome.typesafe
 
+import grizzled.slf4j.Logging
+
 import scala.concurrent.Future
 
-trait Runnable {
+trait Runnable extends Logging {
   def run(): Future[Any]
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+overridden.config = "value"

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/src/test/scala/uk/ac/wellcome/typesafe/WellcomeTypesafeAppTest.scala
+++ b/src/test/scala/uk/ac/wellcome/typesafe/WellcomeTypesafeAppTest.scala
@@ -1,0 +1,54 @@
+package uk.ac.wellcome.typesafe
+
+import com.typesafe.config.Config
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+
+class WellcomeTypesafeAppTest extends AnyFunSpec with Matchers {
+  var calledWith: Option[Config] = None
+
+  class DummyRunnable(config: Config) extends Runnable {
+    override def run(): Future[Any] = Future {
+      calledWith = Some(config)
+
+      info("that I shall say goodnight till it be morrow")
+    }
+  }
+
+  object DummyWellcomeTypesafeApp extends WellcomeTypesafeApp {
+    runWithConfig { config: Config =>
+      info("parting is such sweet sorrow")
+
+      new DummyRunnable(config)
+    }
+  }
+
+
+  describe("when main is called") {
+    DummyWellcomeTypesafeApp.main(Array.empty)
+
+    val config = calledWith.get
+
+    it("should call run in the set Runnable") {
+      calledWith shouldBe a[Some[_]]
+    }
+
+    it("should set the expected logging config") {
+      val loggers = config.getList("akka.loggers")
+      loggers.size() shouldBe 1
+      loggers.get(0).unwrapped() shouldBe "akka.event.slf4j.Slf4jLogger"
+
+      val loggingFilter = config.getString("akka.logging-filter")
+      loggingFilter shouldBe "akka.event.slf4j.Slf4jLoggingFilter"
+    }
+
+    it("should set the expected overridden config") {
+      val overriddenConfig = config.getString("overridden.config")
+      overriddenConfig shouldBe "value"
+    }
+  }
+}


### PR DESCRIPTION
Include Logback and `akka-slf4j` as dependencies.

`akka-slf4j` is required to ensure akka logs use the sl4j adapter: https://doc.akka.io/docs/akka/current/logging.html

This change also includes some tests to check config is set correctly.